### PR TITLE
logging and exit

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 Release 0.4-1:
   * Rollback tests.
   * Added flush.console() to push output buffer to osx and windows console.
+  * Fixed no quit server when set to FALSE.
 
 Release 0.4-0:
   * Fixed warning precedence for small port values.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+Release 0.4-1:
+  * Rollback tests.
+  * Added flush.console() to push output buffer to osx and windows console.
+
 Release 0.4-0:
   * Fixed warning precedence for small port values.
   * Fixed client timer printing.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: remoter
 Type: Package
 Title: Remote R: Control a Remote R Session from a Local One
-Version: 0.4-0
+Version: 0.4-1
 Description: A set of utilities for client/server computing with R, controlling
     a remote R session (the server) from a local one (the client).  Simply set
     up a server (see package vignette for more details) and connect to it from

--- a/R/exit.r
+++ b/R/exit.r
@@ -19,7 +19,7 @@
 #' with the client.
 #' @param q.server
 #' Logical; if \code{TRUE}, then the server calls \code{q("no")}
-#' after shuting down with the client.  This is useful for cases
+#' after shutting down with the client.  This is useful for cases
 #' where the server is running in an interactive R session, and you
 #' wish to shut the entire thing down.
 #' @param addr,port
@@ -55,10 +55,15 @@ exit <- function(client.only=TRUE, q.server=TRUE)
     set(client_called_exit, TRUE)
     # logprint("client disconnected with call to exit()")
   
-  if (!client.only && q.server)
+  if (!client.only)
   {
     if (iam("remote") && interactive())
-      set(kill_interactive_server, TRUE)
+    {
+      if (q.server)
+        set(kill_interactive_server, TRUE)
+      else
+        set(kill_interactive_server, FALSE)
+    }
   }
 
   return(invisible(TRUE))

--- a/R/logging.r
+++ b/R/logging.r
@@ -40,6 +40,7 @@ logfile_init <- function()
 logprint_file <- function(logmsg)
 {
   cat(logmsg, file=getval(logfile), append=TRUE)
+  utils::flush.console()
   invisible()
 }
 


### PR DESCRIPTION
- logging: I finally got time to fix this. The osx and windows console need to be flushed when messages are cat or print because output/error buffers are used for messaging controls. R windows gui is fine now. I am not sure about osx, but the function man help says so.
- exit: The exit server only, but not kill the server. So that I can see what left on server interactively.
