### PR TITLE
remoter::batch(): fix access past end of src vector

### DIFF
--- a/R/batch.r
+++ b/R/batch.r
@@ -109,6 +109,9 @@ remoter_repl_batch <- function(src, env=globalenv())
     
     while (TRUE)
     {
+      if (line > len)
+        break
+
       tmp <- src[line]
       
       if (gsub(tmp, pattern=" +", replacement="") == "")


### PR DESCRIPTION
When a script ends with an empty line or a line containing only spaces (with an optional newline at the end), then the following error occurs:
```
Error in if (gsub(tmp, pattern = " +", replacement = "") == "") { :
  missing value where TRUE/FALSE needed
Calls: <Anonymous> -> remoter_repl_batch
Execution halted
```

This a fix for the above issue. Here are some minimal examples of scripts with the above issue:
```
$ Rscript -e 'remoter::batch(script="")'

Error in if (gsub(tmp, pattern = " +", replacement = "") == "") { :
  missing value where TRUE/FALSE needed
Calls: <Anonymous> -> remoter_repl_batch
Execution halted


$ Rscript -e 'remoter::batch(script=" ")'

Error in if (gsub(tmp, pattern = " +", replacement = "") == "") { :
  missing value where TRUE/FALSE needed
Calls: <Anonymous> -> remoter_repl_batch
Execution halted


$ Rscript -e 'remoter::batch(script=" \n")'

Error in if (gsub(tmp, pattern = " +", replacement = "") == "") { :
  missing value where TRUE/FALSE needed
Calls: <Anonymous> -> remoter_repl_batch
Execution halted


$ Rscript -e 'remoter::batch(script=" \n ")'

Error in if (gsub(tmp, pattern = " +", replacement = "") == "") { :
  missing value where TRUE/FALSE needed
Calls: <Anonymous> -> remoter_repl_batch
Execution halted


$ Rscript -e 'remoter::batch(script="1+1\n ")'

[1] 2
Error in if (gsub(tmp, pattern = " +", replacement = "") == "") { :
  missing value where TRUE/FALSE needed
Calls: <Anonymous> -> remoter_repl_batch
Execution halted


$ Rscript -e 'remoter::batch(script="1+1\n\n")'

[1] 2
Error in if (gsub(tmp, pattern = " +", replacement = "") == "") { :
  missing value where TRUE/FALSE needed
Calls: <Anonymous> -> remoter_repl_batch
Execution halted
```