### PR TITLE
feature: serialize version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: remoter
 Type: Package
 Title: Remote R: Control a Remote R Session from a Local One
-Version: 0.4-1
+Version: 0.4-1.9001
 Description: A set of utilities for client/server computing with R, controlling
     a remote R session (the server) from a local one (the client).  Simply set
     up a server (see package vignette for more details) and connect to it from

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: remoter
 Type: Package
 Title: Remote R: Control a Remote R Session from a Local One
-Version: 0.4-1.9001
+Version: 0.4-1
 Description: A set of utilities for client/server computing with R, controlling
     a remote R session (the server) from a local one (the client).  Simply set
     up a server (see package vignette for more details) and connect to it from

--- a/R/batch.r
+++ b/R/batch.r
@@ -27,6 +27,10 @@
 #' @param timer
 #' Logical; should the "performance prompt", which shows timing
 #' statistics after every command, be used?
+#' @param serialversion
+#' NULL or numeric; the workspace format version to use when serializing.
+#' NULL specifies the current default version. The only other supported
+#' values are 2 and 3.
 #' 
 #' @examples
 #' \dontrun{
@@ -48,9 +52,10 @@
 #' 
 #' @export
 batch <- function(addr="localhost", port=55555, password=NULL, file, script,
-  timer=FALSE)
+  timer=FALSE, serialversion=NULL)
 {
   check.is.flag(timer)
+  check(is.null(serialversion) || is.inty(serialversion))
   validate_address(addr)
   addr <- scrub_addr(addr)
   validate_port(port, warn=FALSE)
@@ -80,6 +85,7 @@ batch <- function(addr="localhost", port=55555, password=NULL, file, script,
   set(port, port)
   set(remote_addr, addr)
   set(clientpw, password)
+  set(serialversion, serialversion)
   
   set(isbatch, TRUE)
   

--- a/R/client.r
+++ b/R/client.r
@@ -30,16 +30,21 @@
 #' @param timer
 #' Logical; should the "performance prompt", which shows timing
 #' statistics after every command, be used?
+#' @param serialversion
+#' NULL or numeric; the workspace format version to use when serializing.
+#' NULL specifies the current default version. The only other supported
+#' values are 2 and 3.
 #' 
 #' @return
 #' Returns \code{TRUE} invisibly on successful exit.
 #' 
 #' @export
 client <- function(addr="localhost", port=55555, password=NULL,
-  prompt="remoter", timer=FALSE)
+  prompt="remoter", timer=FALSE, serialversion=NULL)
 {
   check.is.flag(timer)
   check.is.string(prompt)
+  check(is.null(serialversion) || is.inty(serialversion))
   validate_address(addr)
   addr <- scrub_addr(addr)
   validate_port(port, warn=FALSE)
@@ -54,6 +59,7 @@ client <- function(addr="localhost", port=55555, password=NULL,
   set(port, port)
   set(remote_addr, addr)
   set(clientpw, password)
+  set(serialversion, serialversion)
   
   set(isbatch, FALSE)
 

--- a/R/comms.r
+++ b/R/comms.r
@@ -12,14 +12,19 @@
 
 send_unsecure <- function(data, send.more=FALSE)
 {
-  pbdZMQ::send.socket(getval(socket), data=data, send.more=send.more)
+  serialversion = getval(serialversion)
+  if (is.null(serialversion))
+    pbdZMQ::send.socket(getval(socket), data=data, send.more=send.more)
+  else
+    pbdZMQ::send.socket(getval(socket), data=data, send.more=send.more,
+                        serialversion=serialversion)
 }
 
 
 
 send_secure <- function(data, send.more=FALSE)
 {
-  serialized <- serialize(data, NULL)
+  serialized <- serialize(data, NULL, version=getval(serialversion))
   encrypted <- sodium::auth_encrypt(serialized, getkey(private), getkey(theirs))
   send_unsecure(data=encrypted, send.more=send.more)
 }

--- a/R/server.r
+++ b/R/server.r
@@ -41,13 +41,18 @@
 #' objects recreated in the global environment.  This is useful in IDE's like
 #' RStudio, but it carries a performance penalty.  For terminal users, this is
 #' not recommended.
+#' @param serialversion
+#' NULL or numeric; the workspace format version to use when serializing.
+#' NULL specifies the current default version. The only other supported
+#' values are 2 and 3.
 #' 
 #' @return
 #' Returns \code{TRUE} invisibly on successful exit.
 #' 
 #' @export
 server <- function(port=55555, password=NULL, maxretry=5, secure=has.sodium(),
-  log=TRUE, verbose=FALSE, showmsg=FALSE, userpng=TRUE, sync=TRUE)
+  log=TRUE, verbose=FALSE, showmsg=FALSE, userpng=TRUE, sync=TRUE,
+  serialversion=NULL)
 {
   if (length(port) == 1 && port == 0)
     port <- pbdZMQ::random_open_port()
@@ -61,6 +66,7 @@ server <- function(port=55555, password=NULL, maxretry=5, secure=has.sodium(),
   check.is.flag(showmsg)
   check.is.flag(userpng)
   check.is.flag(sync)
+  check(is.null(serialversion) || is.inty(serialversion))
   
   if (!log && verbose)
     log <- TRUE
@@ -81,6 +87,7 @@ server <- function(port=55555, password=NULL, maxretry=5, secure=has.sodium(),
   set(secure, secure)
   set(sync, sync)
   set(password, pwhash(password))
+  set(serialversion, serialversion)
   
   logfile_init()
   

--- a/R/state.r
+++ b/R/state.r
@@ -27,6 +27,7 @@ reset_state <- function()
   set(clientpw, NULL)
   set(maxattempts, 5)
   set(isbatch, FALSE)
+  set(serialversion, NULL)
   
   # logs
   set(serverlog, TRUE)

--- a/man/batch.Rd
+++ b/man/batch.Rd
@@ -5,7 +5,7 @@
 \title{Batch Execution}
 \usage{
 batch(addr = "localhost", port = 55555, password = NULL, file,
-  script, timer = FALSE)
+  script, timer = FALSE, serialversion = NULL)
 }
 \arguments{
 \item{addr}{The remote host/address/endpoint.}
@@ -27,6 +27,10 @@ this or \code{file} (but not both) should be provided.}
 
 \item{timer}{Logical; should the "performance prompt", which shows timing
 statistics after every command, be used?}
+
+\item{serialversion}{NULL or numeric; the workspace format version to use when serializing.
+NULL specifies the current default version. The only other supported
+values are 2 and 3.}
 }
 \value{
 Returns \code{TRUE} invisibly on successful exit.

--- a/man/client.Rd
+++ b/man/client.Rd
@@ -5,7 +5,7 @@
 \title{Client Launcher}
 \usage{
 client(addr = "localhost", port = 55555, password = NULL,
-  prompt = "remoter", timer = FALSE)
+  prompt = "remoter", timer = FALSE, serialversion = NULL)
 }
 \arguments{
 \item{addr}{The remote host/address/endpoint.}
@@ -23,6 +23,10 @@ interactively asked to enter the password.}
 
 \item{timer}{Logical; should the "performance prompt", which shows timing
 statistics after every command, be used?}
+
+\item{serialversion}{NULL or numeric; the workspace format version to use when serializing.
+NULL specifies the current default version. The only other supported
+values are 2 and 3.}
 }
 \value{
 Returns \code{TRUE} invisibly on successful exit.

--- a/man/server.Rd
+++ b/man/server.Rd
@@ -6,7 +6,8 @@
 \usage{
 server(port = 55555, password = NULL, maxretry = 5,
   secure = has.sodium(), log = TRUE, verbose = FALSE,
-  showmsg = FALSE, userpng = TRUE, sync = TRUE)
+  showmsg = FALSE, userpng = TRUE, sync = TRUE,
+  serialversion = NULL)
 }
 \arguments{
 \item{port}{The port (number) that will be used for communication between 
@@ -36,6 +37,10 @@ the 'sodium' package is available.}
 objects recreated in the global environment.  This is useful in IDE's like
 RStudio, but it carries a performance penalty.  For terminal users, this is
 not recommended.}
+
+\item{serialversion}{NULL or numeric; the workspace format version to use when serializing.
+NULL specifies the current default version. The only other supported
+values are 2 and 3.}
 }
 \value{
 Returns \code{TRUE} invisibly on successful exit.


### PR DESCRIPTION
The package remoter does not have the capability to transfer data between a server running R version 3.6.1 and a client running R version 3.4.4. The reason is that R 3.6.1 by default serializes with format version 3, which is not readable by R 3.4.4.

https://www.rdocumentation.org/packages/base/versions/3.6.1/topics/serialize

I have a set up where I need to do the above transfer and thus I create this pull request.

This commit adds an optional `serialversion` argument to the functions `client`, `server`, and `batch` that allows finer control of the serialization process. The default value of this argument is NULL and its two other possible values are 2 and 3. The behavior of the code without passing this argument is the same as before. However, when setting `serialversion` to 2, one can transfer data between different versions of R, as mentioned above.

It is not only necessary to change remoter, but also package pbdZMQ, on which remoter depends, has to be changed. For this reason, I have also created the following pull request:
https://github.com/snoweye/pbdZMQ/pull/67